### PR TITLE
Adds document click listener and new options.

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -73,13 +73,15 @@
     </div>
   </div>
 
-  <script src="/bundle.js"></script>
+  <script crossorigin src="/bundle.js"></script>
 
   <script>
     /**
      * Initialize Perry
      */
-    new Perry();
+    new Perry({
+      clicks: true
+    });
 
     /**
      * Configure playground handlers

--- a/src/interfaces/PerryElementData.ts
+++ b/src/interfaces/PerryElementData.ts
@@ -1,0 +1,10 @@
+export default interface ElementData {
+  id: string,
+  dataset: object,
+  tagName: string,
+  className: string,
+  classList: ReadonlyArray<string>,
+  nodeName: string,
+  textContent: string,
+  disabled: boolean,
+};

--- a/src/interfaces/PerryOptions.ts
+++ b/src/interfaces/PerryOptions.ts
@@ -7,4 +7,6 @@ export default interface PerryOptions {
   cookies: boolean,
   localStorage: boolean,
   sessionStorage: boolean,
+  clicks: boolean,
+  ignoreScriptErrors: boolean
 };

--- a/src/packages/default-options/index.ts
+++ b/src/packages/default-options/index.ts
@@ -2,13 +2,15 @@ import PerryOptions from '../../interfaces/PerryOptions';
 
 const defaultOptions: PerryOptions = {
   credentials: { /** empty credentials */ },
-  clearOnReload: false,
   log: false,
   warn: true,
   error: true,
   cookies: false,
   localStorage: false,
   sessionStorage: false,
+  clicks: false,
+  clearOnReload: false,
+  ignoreScriptErrors: false,
 };
 
 export default defaultOptions;

--- a/src/packages/listen-document-clicks/index.ts
+++ b/src/packages/listen-document-clicks/index.ts
@@ -1,0 +1,50 @@
+import writeToStore from '../write-to-store';
+import PerryOptions from '../../interfaces/PerryOptions';
+import mapHTMLElementToElementData from '../map-html-element-to-element-data';
+
+export default function listenWindowErrors(options: PerryOptions): void {
+  document.onclick = function (event: MouseEvent) {
+    const view: Window = event.view;
+    const screen: Screen = view.screen;
+
+    /** casting EventTarget type to HTMLElement type */
+    const element: HTMLElement = event.target as HTMLElement;
+    
+    /** couldn't get view.visualViewport from Window type */
+    const viewport: any = (view as any).visualViewport;
+    
+    options.clicks && writeToStore({
+      name: 'document',
+      property: 'onclick',
+      params: {
+        event: {
+          type: event.type,
+          x: event.x,
+          y: event.y,
+          screenX: event.screenX,
+          screenY: event.screenY,
+          pageX: event.pageX,
+          pageY: event.pageY,
+          offsetX: event.offsetX,
+          offsetY: event.offsetY,
+          /** couldn't get event.path from MouseEvent type */
+          path: (event as any).path.map(mapHTMLElementToElementData)
+        },
+        target: mapHTMLElementToElementData(element),
+        screen: {
+          width: screen.width,
+          availWidth: screen.availWidth,
+          height: screen.height,
+          availHeight: screen.availHeight,
+          /** couldn't get screen.orientation from Screen type */
+          orientation: (screen as any).orientation.type,
+        },
+        viewport: {
+          scale: viewport.scale,
+          width: viewport.width,
+          height: viewport.height,
+        }
+      }
+    });
+  };
+}

--- a/src/packages/listen-window-errors/index.ts
+++ b/src/packages/listen-window-errors/index.ts
@@ -1,24 +1,40 @@
 import writeToStore from '../write-to-store';
 import PerryOptions from '../../interfaces/PerryOptions';
 
+const isScriptError = (message: string): boolean =>
+  message.toLowerCase().indexOf("script error") > -1
+
 export default function listenWindowErrors(options: PerryOptions): void {
-  window.onerror = function (
+  const handler = function (
     message: string,
     url: string,
     line: number,
     column: number,
     error: any,
-  ) {
+  ): void {
+    /** Don't record Scripting errors due to browser security blocks. */
+    /** Any solutions for this will be appreciated. */
+    /** See: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onerror#notes */
+    const isUnhandableError = isScriptError(message);
+    
+    if (isUnhandableError && options.ignoreScriptErrors) {
+      return;  
+    }
+
     options.error && writeToStore({
-      name: 'window',
+      name: isUnhandableError
+        ? 'script'
+        : 'window',
       property: 'onerror',
       params: {
         message,
         url,
         line,
         column,
-        stack: error.stack,
+        stack: error && error.stack,
       }
     });
   }
+
+  window.onerror = handler;
 }

--- a/src/packages/map-html-element-to-element-data/index.ts
+++ b/src/packages/map-html-element-to-element-data/index.ts
@@ -1,0 +1,16 @@
+import PerryElementData from '../../interfaces/PerryElementData';
+
+const mapClassListToArray =
+  (classList: DOMTokenList = ({} as DOMTokenList)): ReadonlyArray<string> => 
+    [].slice.call(classList);
+
+export default (element: HTMLElement): PerryElementData => ({
+  id: element.id,
+  dataset: element.dataset,
+  tagName: element.tagName,
+  nodeName: element.nodeName,
+  className: element.className,
+  classList: mapClassListToArray(element.classList),
+  textContent: element.textContent,
+  disabled: (element as HTMLButtonElement).disabled,
+});

--- a/src/packages/options-schema/index.ts
+++ b/src/packages/options-schema/index.ts
@@ -10,4 +10,6 @@ export default object({
   cookies: boolean(),
   localStorage: boolean(),
   sessionStorage: boolean(),
+  clicks: boolean(),
+  ignoreScriptErrors: boolean()
 }).noUnknown();

--- a/src/packages/perry/index.ts
+++ b/src/packages/perry/index.ts
@@ -13,6 +13,9 @@ import applyConsoleProxy from '../apply-console-proxy';
 /** Listens and stores interactions in window.onerror */
 import listenWindowErrors from '../listen-window-errors';
 
+/** Listens and stores document clicks */
+import listenDocumentClicks from '../listen-document-clicks';
+
 /** Clears perry store */
 import clearStore from '../clear-store';
 
@@ -45,6 +48,7 @@ export default class Perry {
     
     applyConsoleProxy(finalOptions);
     listenWindowErrors(finalOptions);
+    listenDocumentClicks(finalOptions);
     renderBugReporter(finalOptions);
   }
 };

--- a/src/packages/write-to-store/index.ts
+++ b/src/packages/write-to-store/index.ts
@@ -17,7 +17,7 @@ export default function writeToStore({
 
   const newHistory: ReadonlyArray<PerryStoreEvent> = [
     ...history,
-    event  
+    event
   ];
 
   localStorage.setItem(key, JSON.stringify(newHistory));


### PR DESCRIPTION
This pull request introduces the document click listener.

The event, element, screen and viewport data are now
gathered every time a click is made in the page.

Due to this, users can also disable this feature by
setting options.click to false.

Also, there is quite some errors we cannot yet catch,
such as TypeErrors in external scripts (CORS invalid).

For those, we are currently giving the option
for the user to ignore them through
setting `options.ignoreScriptErrors` to false.

Some screenshots:

 - OnClick history
![onclick history](https://user-images.githubusercontent.com/6154901/41618083-7e77a9aa-7402-11e8-9de5-20986cc86296.JPG)

 - Script Error catching
![scripterr](https://user-images.githubusercontent.com/6154901/41618121-9335174c-7402-11e8-90bf-b0612c62e0bc.JPG)
![scripterrlog](https://user-images.githubusercontent.com/6154901/41618122-93627ed0-7402-11e8-9b7b-cc7b5a184c0a.JPG)
