### PR TITLE
Adds plugin support and enhanced Preview

### DIFF
--- a/src/components/Widget/index.test.tsx
+++ b/src/components/Widget/index.test.tsx
@@ -9,7 +9,7 @@ import Widget from "./";
 
 describe("Widget Snapshot", () => {
   it("should render with content", () => {
-    const tree = render(<Widget {...defaultOptions} />);
+    const tree = render(<Widget onSubmit={() => {}} />);
     expect(tree).toMatchSnapshot();
   });
 });

--- a/src/components/Widget/index.tsx
+++ b/src/components/Widget/index.tsx
@@ -4,15 +4,7 @@ import Flex from "grid-styled/dist/Flex"
 import ButtonOutline from "rebass/dist/ButtonOutline";
 import Provider from "rebass/dist/Provider";
 
-export interface WidgetProps {
-  credentials: object,
-  log: boolean,
-  warn: boolean,
-  error: boolean,
-  cookies: boolean,
-  localStorage: boolean,
-  sessionStorage: boolean,
-};
+import WidgetProps from '../../interfaces/WidgetProps';
 
 const Widget = (props: WidgetProps) => (
   <Provider>
@@ -21,7 +13,7 @@ const Widget = (props: WidgetProps) => (
       justifyContent="center"
     >
       <Box m={4}>
-        <ButtonOutline>
+        <ButtonOutline onClick={props.onSubmit}>
           Bug Reporter Widget
         </ButtonOutline>
       </Box>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -6,22 +6,22 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Perry.js Preview</title>
 
+  <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css">
   <style>
     .preview {
-      width: 100%;
-      max-width: 1100px;
-      margin: 80px auto;
-      border: 1px dashed rgba(0, 0, 0, 0.2);
+      padding: 1.8em;
       position: relative;
+      border: 1px dashed rgba(0, 0, 0, 0.2);
     }
 
     .preview::before {
-      content: 'PERRY.JS PREVIEW';
-      position: absolute;
-      display: block;
-      top: -18px;
+      top: -20px;
+      left: 0px;
       font-size: 11px;
       color: rgba(0, 0, 0, 0.5);
+      display: block;
+      content: 'PERRY.JS PREVIEW';
+      position: absolute;
     }
 
     .actions {
@@ -31,72 +31,81 @@
       margin: 1em 6em;
     }
 
-    .actions button {
-      background-color: transparent;
-      border: 2px solid #444;
-      padding: 0.5em 0.8em;
-      margin-bottom: 0.5em;
-      min-width: 75px;
-      cursor: pointer;
-      outline: none;
-    }
-
-    .actions button:hover {
-      box-shadow: 0 0 0 1pt #fff;
-      background-color: #444;
-      color: #fff;
-    }
-
-    .actions button:active {
-      box-shadow: 0 0 0 2pt #fff;
-      background-color: #222;
-      color: #fff;
-    }
-
-    .actions::before {
-      content: 'ACTIONS';
-      display: block;
-      font-size: 11px;
-      margin-bottom: .4em;
-      color: rgba(0, 0, 0, 0.5);
-    }
   </style>
 </head>
 
-<body class="preview">
-  <div class="actions">
-    <div>
-      <button id="action-log">Console Log</button>
-      <button id="action-warn">Console Warn</button>
-      <button id="action-error">Console Error</button>
-      <button id="action-throw-error">Throw Error</button>
+<body>
+  <div class="container">
+    <div class="row">
+      <img src="https://raw.githubusercontent.com/perry-js/perry/master/.github/assets/logo.png" alt="Perry.js">
+      <h1>Perry.js</h1>
+      <h5>Perry.js is a Javascript library to help creating meaningful bug reports.</h5>
+      
+      <p>Perry is a spy. His job is to help you and your mates to fight against bugs.</p>
+      
+      <p>
+        He does it by spying your user usage. He listens to console logs, warns, errors, and user interaction such as clicks.<br />
+        He writes all this data inside your page LocalStorage under its specific namespacing.<br /> 
+        After gathering all this data, it wraps it all together into a serializable Bug Report, which contains:
+      </p>
+      
+      <ul>
+        <li>Logs</li>
+        <li>Warnings</li>
+        <li>Errors</li>
+        <li>MouseEvent Data (click, target element, screen position, screen size and so on)</li>
+        <li>Cookies Data</li>
+        <li>Local Storage Data</li>
+        <li>Session Storage Data (soon) </li>
+        <li>Print Screens (soon)</li>
+      </ul>
+      
+      <p>
+        He also will be able to reproduce these reports automatically by importing this serializable json<br />
+        and rerunning the user interaction as if he was the user, so he can show you good a spy can be.
+      </p>
+    </div>
+
+    <hr />
+    <br />
+
+    <div class="preview">
+      <p>
+        Perry is already taking care of this page you're reading right now.<br />
+        Open DevTools, see the logs and inspect localStorage while interacting
+      </p>
+
+      <button id="action-log">Console: <span style="color: #449;">Log</span></button>
+      <button id="action-warn">Console: <span style="color: #f80">Warn</span></button>
+      <button id="action-error">Console: <span style="color: #f00">Error</span></button>
+      <button id="action-throw-error"><span style="color: #f00">Throw Error</span></button>
+      <button id="clear-local-storage"><span style="color: #449;">Clear Local Storage</span></button>
     </div>
   </div>
-
-  <script crossorigin src="/bundle.js"></script>
+  
+  <script src="/bundle.js"></script>
 
   <script>
-    /**
-     * Initialize Perry
-     */
-    new Perry({
-      clicks: true
-    });
-
-    /**
-     * Configure playground handlers
-     */
+    /** Setup playground */
     const buttons = {
       log: document.getElementById("action-log"),
       warn: document.getElementById("action-warn"),
       error: document.getElementById("action-error"),
       throwError: document.getElementById("action-throw-error"),
+      clearLocalStorage: document.getElementById("clear-local-storage")
     };
-
+    
     buttons.log.addEventListener("click", () => console.log('ama simple info log'));
     buttons.warn.addEventListener("click", () => console.warn('ama warning'));
     buttons.error.addEventListener("click", () => console.error('ama error'));
     buttons.throwError.addEventListener("click", () => { throw new Error('ama boom') });
+    buttons.clearLocalStorage.addEventListener("click", () => localStorage.clear());
+
+    /** Initialize Perry.js */
+    new Perry({
+      log: true,
+      clicks: true
+    });
   </script>
 </body>
 

--- a/src/interfaces/PerryOptions.ts
+++ b/src/interfaces/PerryOptions.ts
@@ -1,12 +1,12 @@
 export default interface PerryOptions {
-  credentials: object,
-  clearOnReload: boolean,
   log: boolean,
   warn: boolean,
   error: boolean,
+  clicks: boolean,
   cookies: boolean,
   localStorage: boolean,
   sessionStorage: boolean,
-  clicks: boolean,
-  ignoreScriptErrors: boolean
+  clearOnReload: boolean,
+  ignoreScriptErrors: boolean,
+  plugins: Array<Function>
 };

--- a/src/interfaces/PerryReport.ts
+++ b/src/interfaces/PerryReport.ts
@@ -1,0 +1,9 @@
+import PerryStoreEvent from './PerryStoreEvent';
+
+export default interface Report {
+  logs: Array<PerryStoreEvent>;
+  warns: Array<PerryStoreEvent>;
+  errors: Array<PerryStoreEvent>;
+  clicks: Array<PerryStoreEvent>;
+  cookies: string;
+};

--- a/src/interfaces/WidgetProps.ts
+++ b/src/interfaces/WidgetProps.ts
@@ -1,0 +1,3 @@
+export default interface WidgetProps {
+  onSubmit?: Function,
+};

--- a/src/packages/aggregate-report/index.ts
+++ b/src/packages/aggregate-report/index.ts
@@ -1,0 +1,24 @@
+import PerryReport from '../../interfaces/PerryReport';
+import PerryStoreEvent from '../../interfaces/PerryStoreEvent';
+
+const getItemFor = (method: string) =>
+  JSON.parse(localStorage.getItem(getKeyFor(method)));
+
+const getKeyFor = (method: string) => `perry::${method}::history`;
+
+const orArray = (expression: any) => expression || [];
+
+export default function aggregateReport(): PerryReport {
+  const result: PerryReport = {
+    logs: getItemFor("console.log"),
+    warns: getItemFor("console.warn"),
+    errors: [
+      ...orArray(getItemFor("console.error")),
+      ...orArray(getItemFor("window.onerror")),
+    ],
+    cookies: document.cookie,
+    clicks: getItemFor("document.onclick")
+  };
+
+  return result;
+}

--- a/src/packages/default-options/index.ts
+++ b/src/packages/default-options/index.ts
@@ -1,16 +1,16 @@
 import PerryOptions from '../../interfaces/PerryOptions';
 
 const defaultOptions: PerryOptions = {
-  credentials: { /** empty credentials */ },
   log: false,
   warn: true,
   error: true,
+  clicks: false,
   cookies: false,
   localStorage: false,
   sessionStorage: false,
-  clicks: false,
   clearOnReload: false,
   ignoreScriptErrors: false,
+  plugins: []
 };
 
 export default defaultOptions;

--- a/src/packages/options-schema/index.ts
+++ b/src/packages/options-schema/index.ts
@@ -1,15 +1,16 @@
 import object from "yup/lib/object";
 import boolean from "yup/lib/boolean";
+import array from "yup/lib/array";
 
 export default object({
-  credentials: object(),
-  clearOnReload: boolean(),
   log: boolean(),
   warn: boolean(),
   error: boolean(),
+  clicks: boolean(),
   cookies: boolean(),
   localStorage: boolean(),
   sessionStorage: boolean(),
-  clicks: boolean(),
-  ignoreScriptErrors: boolean()
+  ignoreScriptErrors: boolean(),
+  clearOnReload: boolean(),
+  plugins: array(),
 }).noUnknown();

--- a/src/packages/render-widget/index.tsx
+++ b/src/packages/render-widget/index.tsx
@@ -1,9 +1,12 @@
 import { h } from "preact"; 
 import habitat from "preact-habitat";
 import Widget from "../../components/Widget";
+import WidgetProps from "../../interfaces/WidgetProps";
 
-const renderBugReporter = options => {
-  const Wrapper = () => <Widget {...options} />;
+const renderWidget = (props: WidgetProps) => {
+  const Wrapper = () => (
+    <Widget onSubmit={props.onSubmit} />
+  );
   
   const { render } = habitat(Wrapper);
 
@@ -13,4 +16,4 @@ const renderBugReporter = options => {
   });
 };
 
-export default renderBugReporter;
+export default renderWidget;


### PR DESCRIPTION
This commit adds plugins support to Perry.

Now it accepts an options.plugins array property.

Plugins are just plain functions that are executed
when the user submits the report.

Plugins are functions that receive the report as the only argument.

Removed the options.credentials prop in order to make
it single purposed.

![screencapture-localhost-8080-2018-06-20-02_19_39](https://user-images.githubusercontent.com/6154901/41630677-81b4c5ac-7430-11e8-816a-3df7be42bbf7.png)
