### PR TITLE
Feature: perry.notify(error)

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -31,7 +31,6 @@
       flex-direction: column;
       margin: 1em 6em;
     }
-
   </style>
 </head>
 
@@ -79,7 +78,8 @@
       <button id="action-log">Console: <span style="color: #449;">Log</span></button>
       <button id="action-warn">Console: <span style="color: #f80">Warn</span></button>
       <button id="action-error">Console: <span style="color: #f00">Error</span></button>
-      <button id="action-throw-error"><span style="color: #f00">Throw Error</span></button>
+      <button id="action-throw-handled-exception"><span style="color: #f00">Throw Handled Exception</span></button>
+      <button id="action-throw-unhandled-exception"><span style="color: #f00">Throw Unhandled Exception</span></button>
       <button id="clear-local-storage"><span style="color: #449;">Clear Local Storage</span></button>
     </div>
   </div>
@@ -87,27 +87,8 @@
   <script src="/bundle.js"></script>
 
   <script>
-    /** Setup playground */
-    const buttons = {
-      log: document.getElementById("action-log"),
-      warn: document.getElementById("action-warn"),
-      error: document.getElementById("action-error"),
-      throwError: document.getElementById("action-throw-error"),
-      clearLocalStorage: document.getElementById("clear-local-storage")
-    };
-
-    buttons.log.addEventListener("click", () => console.log('ama simple info log'));
-    buttons.warn.addEventListener("click", () => console.warn('ama warning'));
-    buttons.error.addEventListener("click", () => console.error('ama error'));
-    buttons.throwError.addEventListener("click", () => { throw new Error('ama boom') });
-    buttons.clearLocalStorage.addEventListener("click", () => localStorage.clear());
-
-    setInterval(() => {
-      throw new Error()
-    }, 1000);
-
     /** Initialize Perry.js */
-    new Perry({
+    const perry = new Perry({
       log: true,
       clicks: true,
       plugins: [
@@ -116,6 +97,19 @@
         }
       ]
     });
+
+    document.getElementById("action-log").addEventListener("click", () => console.log('ama simple info log'));
+    document.getElementById("action-warn").addEventListener("click", () => console.warn('ama warning'));
+    document.getElementById("action-error").addEventListener("click", () => console.error('ama error'));
+    document.getElementById("action-throw-unhandled-exception").addEventListener("click", () => { throw new Error('ama boom') });
+    document.getElementById("action-throw-handled-exception").addEventListener("click", () => {
+      try {
+        throw new Error('ama boom');
+      } catch (e) {
+        perry.notify(e);
+      }
+    })
+    document.getElementById("clear-local-storage").addEventListener("click", () => { localStorage.clear() })
   </script>
 </body>
 

--- a/src/interfaces/PerryReport.ts
+++ b/src/interfaces/PerryReport.ts
@@ -8,4 +8,5 @@ export default interface PerryReport extends PerryReportInfo {
   warns: Array<PerryStoreEvent>;
   errors: Array<PerryStoreEvent>;
   clicks: Array<PerryStoreEvent>;
+  notify: Array<PerryStoreEvent>;
 }

--- a/src/packages/aggregate-report/index.ts
+++ b/src/packages/aggregate-report/index.ts
@@ -21,7 +21,8 @@ export default function aggregateReport(reportInfo: PerryReportInfo): PerryRepor
       ...orArray(getItemFor("window.onerror")),
     ],
     cookies: document.cookie,
-    clicks: getItemFor("document.onclick")
+    clicks: getItemFor("document.onclick"),
+    notify: getItemFor("perry.notify")
   };
 
   return result;

--- a/src/packages/features/index.ts
+++ b/src/packages/features/index.ts
@@ -1,5 +1,6 @@
 export default {
   CONSOLE_LISTENER: 'perry::feature::consolelistener',
   DOCUMENT_CLICK_LISTENER: 'perry::feature::documentclicklistener',
-  WINDOW_ERROR_LISTENER: 'perry::feature::windowerrorlistener'
+  WINDOW_ERROR_LISTENER: 'perry::feature::windowerrorlistener',
+  NOTIFY_LISTENER:'perry::feature::notifylistener'
 }

--- a/src/packages/perry-notify/index.ts
+++ b/src/packages/perry-notify/index.ts
@@ -13,7 +13,7 @@ export default function notify(error: Error): void {
     params: {
       name: error.name,
       message: error.message,
-      stack: error && error.stack,
+      stack: error.stack,
     }
   });
 }

--- a/src/packages/perry-notify/index.ts
+++ b/src/packages/perry-notify/index.ts
@@ -1,0 +1,19 @@
+import writeToStore from '@/packages/write-to-store';
+import Features from '@/packages/features';
+import FeatureToggleStore from '@/packages/feature-toggle-store';
+
+export default function notify(error: Error): void {
+  if (!FeatureToggleStore.is(Features.NOTIFY_LISTENER)) {
+    return;
+  }
+
+  return writeToStore({
+    name: 'perry',
+    property: 'notify',
+    params: {
+      name: error.name,
+      message: error.message,
+      stack: error && error.stack,
+    }
+  });
+}

--- a/src/packages/perry/index.ts
+++ b/src/packages/perry/index.ts
@@ -31,8 +31,12 @@ import startListeners from '@/packages/start-listeners';
 /** Toggles the feature switches to false so the listeners stop watching */
 import stopListeners from '@/packages/stop-listeners';
 
+/** Perry stateless notifier */
+import notify from '@/packages/perry-notify';
+
 /** Perry.js class definition */
 export default class Perry {
+  public notify = notify;
   private finalOptions: PerryOptions;
 
   constructor(options: object = {}) {

--- a/src/packages/perry/index.ts
+++ b/src/packages/perry/index.ts
@@ -39,7 +39,7 @@ export default class Perry {
   public notify = notify;
   private finalOptions: PerryOptions;
 
-  constructor(options: object = {}) {
+  constructor(options: PerryOptions = defaultOptions) {
     this.finalOptions = {
       ...defaultOptions,
       ...options,

--- a/src/packages/render-widget/index.tsx
+++ b/src/packages/render-widget/index.tsx
@@ -4,9 +4,7 @@ import Widget from "@/components/Widget";
 import WidgetProps from "@/interfaces/WidgetProps";
 
 const renderWidget = (props: WidgetProps) => {
-  const { render } = habitat(() => <Widget {...props} />);
-
-  render({
+  habitat(() => <Widget {...props} />).render({
     selector: 'body',
     clean: false,
   });

--- a/src/packages/start-listeners/index.ts
+++ b/src/packages/start-listeners/index.ts
@@ -5,4 +5,5 @@ export default function startListeners() {
   FeatureToggleStore.enable(Features.CONSOLE_LISTENER);
   FeatureToggleStore.enable(Features.WINDOW_ERROR_LISTENER);
   FeatureToggleStore.enable(Features.DOCUMENT_CLICK_LISTENER);
+  FeatureToggleStore.enable(Features.NOTIFY_LISTENER);
 }

--- a/src/packages/stop-listeners/index.ts
+++ b/src/packages/stop-listeners/index.ts
@@ -5,4 +5,5 @@ export default function stopListeners() {
   FeatureToggleStore.disable(Features.CONSOLE_LISTENER);
   FeatureToggleStore.disable(Features.WINDOW_ERROR_LISTENER);
   FeatureToggleStore.disable(Features.DOCUMENT_CLICK_LISTENER);
+  FeatureToggleStore.disable(Features.NOTIFY_LISTENER);
 }


### PR DESCRIPTION
Closes #16 

Adds a new "Throw Handled Exception" button to the preview:
![preview-button](https://user-images.githubusercontent.com/6154901/45930460-ebe1a780-bf60-11e8-8a45-62b19361cbbc.JPG)

Stores notifies in a specific local storage namespace:
![logs](https://user-images.githubusercontent.com/6154901/45930465-fbf98700-bf60-11e8-9bb3-fde26fb1f3ea.JPG)

Also logs them together with the report payload:
![logs-2](https://user-images.githubusercontent.com/6154901/45930467-0156d180-bf61-11e8-930c-d66ac24ea4d3.JPG)

