### PR TITLE
Refactor aggregate report

### DIFF
--- a/src/packages/aggregate-report/index.ts
+++ b/src/packages/aggregate-report/index.ts
@@ -9,7 +9,7 @@ const getKeyFor = (method: string) => `perry::${method}::history`;
 const orArray = (expression: any) => expression || [];
 
 export default function aggregateReport(reportInfo: PerryReportInfo): PerryReport {
-  const result: PerryReport = {
+  return {
     title: reportInfo.title,
     description: reportInfo.description,
     screenshotUrl: reportInfo.screenshotUrl,
@@ -17,12 +17,10 @@ export default function aggregateReport(reportInfo: PerryReportInfo): PerryRepor
     warns: getItemFor("console.warn"),
     errors: [
       ...orArray(getItemFor("console.error")),
-      ...orArray(getItemFor("window.onerror")),
+      ...orArray(getItemFor("window.onerror"))
     ],
     cookies: document.cookie,
     clicks: getItemFor("document.onclick"),
     notify: getItemFor("perry.notify")
   };
-
-  return result;
 }

--- a/src/packages/aggregate-report/index.ts
+++ b/src/packages/aggregate-report/index.ts
@@ -1,5 +1,4 @@
 import PerryReport from '@/interfaces/PerryReport';
-import PerryStoreEvent from '@/interfaces/PerryStoreEvent';
 import PerryReportInfo from '@/interfaces/PerryReportInfo';
 
 const getItemFor = (method: string) =>


### PR DESCRIPTION
`PerryStoreEvent` was being imported to index.ts.aggregateReport, but was never used. Also, the function is now returning the object, instead of creating another variable to store it and then return it.

Closes #22