### PR TITLE
Fixed Clear Store test matcher

### DIFF
--- a/src/packages/clear-store/clear-store.test.ts
+++ b/src/packages/clear-store/clear-store.test.ts
@@ -2,6 +2,6 @@ import clearStore from './';
 
 describe('Clear Store', () => {
   it('should clear localStorage', () => {
-    expect(clearStore).toBeUndefined();
+    expect(clearStore()).toBeUndefined();
   });
 });


### PR DESCRIPTION
Even though the `clearStore` function worked as expected, the test was failing because the function wasn't being called properly.