### PR TITLE
Lazy loading standalone

### DIFF
--- a/src/index.ejs
+++ b/src/index.ejs
@@ -4,7 +4,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <script src="http://localhost:8097"></script>
   <title>Perry.js Preview</title>
   <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/skeleton/2.0.4/skeleton.min.css">
   <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/default.min.css">
@@ -53,39 +52,6 @@
       flex-direction: column;
       margin: 1em 6em;
     }
-
-    .pulse {
-      position: fixed;
-      bottom: 30px;
-      right: 30px;
-      display: block;
-      width: 40px;
-      height: 40px;
-      border-radius: 50%;
-      background: #1FA49F;
-      cursor: pointer;
-      box-shadow: 0 0 0 rgba(31, 164, 159, 0.4);
-      animation: pulse 2s infinite;
-    }
-
-    .pulse:hover {
-      animation: none;
-    }
-
-    @keyframes pulse {
-      0% {
-        -moz-box-shadow: 0 0 0 0 rgba(31, 164, 159, 0.4);
-        box-shadow: 0 0 0 0 rgba(31, 164, 159, 0.4);
-      }
-      70% {
-        -moz-box-shadow: 0 0 0 10px rgba(31, 164, 159, 0);
-        box-shadow: 0 0 0 10px rgba(31, 164, 159, 0);
-      }
-      100% {
-        -moz-box-shadow: 0 0 0 0 rgba(31, 164, 159, 0);
-        box-shadow: 0 0 0 0 rgba(31, 164, 159, 0);
-      }
-    }
   </style>
 </head>
 
@@ -115,6 +81,11 @@
       </ul>
 
       <p>
+        All components in Perry are lazy loaded by default.<br />
+        It means that you load Perry's features on demand as you actually use them.
+      </p>
+
+      <p>
         Perry also follows a plugin based approach for sending payloads to external endpoints.
         You are able to provide functions to the <code>plugins</code> option that will process
         the Perry Report Info payload and do whatever they want with them.<br />
@@ -142,17 +113,17 @@
           <tr>
             <td><code>constructor</code></td>
             <td><code>new Perry(options: PerryOptions): Perry</code></td>
-            <td>Returns an instance from Perry with the listeners setup.</td>
+            <td>Returns an instance of Perry.</td>
           </tr>
           <tr>
             <td><code>notify</code></td>
-            <td><code>perry.notify(error: Error): void</code></td>
+            <td><code>perry.notify(error: Error): Promise&lt;void&gt;</code></td>
             <td>A programatic API so you can let perry know of errors without it having to catch them. Useful when handling errors.</td>
           </tr>
           <tr>
             <td><code>render</code></td>
-            <td><code>perry.render(): void</code></td>
-            <td>Creates and appends a <code>#perry-widget</code> element into the document body and renders Perry Widget inside of it.</td>
+            <td><code>perry.render(): Promise&lt;void&gt;</code></td>
+            <td>Fetches the Perry Widget component, appends a <code>#perry-widget</code> element into the document body and renders Perry Widget inside of it.</td>
           </tr>
           <tr>
             <td><code>start</code></td>
@@ -167,7 +138,7 @@
           <tr>
             <td><code>submit</code></td>
             <td><code>perry.submit(reportInfo: IPerryReportInfo): Promise&lt;IPerryReport&gt;</code></td>
-            <td>Aggregates the whole reporting session into the structure defined in the <code>IPerryReport</code> interface, invokes all plugins giving it as an argument and then returns it.</td>
+            <td>Aggregates the whole reporting session into the structure defined in the <code>IPerryReport</code> interface, invokes all plugins giving it as an argument and then returns it. Resolves after executing all the plugins configured.</td>
           </tr>
         </tbody>
       </table>      
@@ -264,9 +235,17 @@
     <div class="box preview">
       <p>
         Perry is already taking care of this page you're reading right now.<br />
+        To render the Perry Widget, you can click in the button below.<br />
+        You can also play with <code>perry.start()</code>, <code>perry.stop()</code> and <code>perry.submit()</code> in the DevTools console.<br /><br/>
         This page has a ConsoleLogPlugin implemented for Perry.<br /><br />
         Open DevTools, start recording, play around, submit the form, and see your console.
       </p>
+
+      <div class="row">
+        <button id="action-render-widget" class="button-primary">Render Perry Widget</button>
+      </div>
+
+      <br />
 
       <button id="action-log">Console: <span style="color: #449;">Log</span></button>
       <button id="action-warn">Console: <span style="color: #f80">Warn</span></button>
@@ -279,9 +258,26 @@
 &lt;script src=&quot;/bundle.js&quot;&gt;&lt;/script&gt;
 
 &lt;script&gt;
+  /* This is an example plugin for handling perry's report */
+  function ConsoleLogPlugin(reportInfo) {
+    console.log(&quot;[Perry Report Info]:&quot;, reportInfo);
+    console.log(&quot;[Perry Report Info]:&quot;, [
+      &quot;&quot;,
+      &quot;This was printed by the ConsoleLogPlugin.&quot;,
+      &quot;It is implemented inline into this test page.&quot;,
+      &quot;To know more about how to implement a Perry Plugin:&quot;,
+      &quot;Checkout this page src code or the github repository.&quot;
+    ].join(&quot;\n&quot;));
+
+    alert([
+      &quot;[Perry Report Info]: Please check your console logs to see the recording report.&quot;,
+      &quot;Sorry for the alert as well, we'll get rid of it soon! &lt;3&quot;
+    ].join(&quot;\n&quot;));
+  }
+
   /* Initialize Perry.js */
   const perry = new Perry({
-    /* Enables log monitoring */
+    /* Enables log recording */
     log: true,
     /* Enables click recording */
     clicks: true,
@@ -289,28 +285,12 @@
     enableScreenRecording: true,
     /* Plugins are ways to handle the bug reporting submission */
     plugins: [
-      function ConsoleLogPlugin(reportInfo) {
-        console.log(&quot;[Perry Report Info]:&quot;, reportInfo);
-        console.log(&quot;[Perry Report Info]:&quot;, [
-          &quot;&quot;,
-          &quot;This was printed by the ConsoleLogPlugin.&quot;,
-          &quot;It is implemented inline into this test page.&quot;,
-          &quot;To know more about how to implement a Perry Plugin:&quot;,
-          &quot;Checkout this page src code or the github repository.&quot;
-        ].join(&quot;\n&quot;));
-
-        alert([
-          &quot;[Perry Report Info]: Please check your console logs to see the recording report.&quot;,
-          &quot;Sorry for the alert as well, we'll get rid of it soon! &lt;3&quot;
-        ].join(&quot;\n&quot;));
-      }
+      ConsoleLogPlugin,
     ]
   });
 
-  /* Renders Perry Widget */
-  perry.render();
-
   /* Attachs listeners to this page code */
+  document.getElementById(&quot;action-render-widget&quot;).addEventListener(&quot;click&quot;, () =&gt; perry.render());
   document.getElementById(&quot;action-log&quot;).addEventListener(&quot;click&quot;, () =&gt; console.log('ama simple info log'));
   document.getElementById(&quot;action-warn&quot;).addEventListener(&quot;click&quot;, () =&gt; console.warn('ama warning'));
   document.getElementById(&quot;action-error&quot;).addEventListener(&quot;click&quot;, () =&gt; console.error('ama error'));
@@ -328,16 +308,31 @@
     </div>
   </div>
 
-  <div class="pulse"></div>
-  
   <script>hljs.initHighlightingOnLoad();</script>
   
   <script src="/bundle.js"></script>
 
   <script>
+    /* This is an example plugin for handling perry's report */
+    function ConsoleLogPlugin(reportInfo) {
+      console.log("[Perry Report Info]:", reportInfo);
+      console.log("[Perry Report Info]:", [
+        "",
+        "This was printed by the ConsoleLogPlugin.",
+        "It is implemented inline into this test page.",
+        "To know more about how to implement a Perry Plugin:",
+        "Checkout this page src code or the github repository."
+      ].join("\n"));
+
+      alert([
+        "[Perry Report Info]: Please check your console logs to see the recording report.",
+        "Sorry for the alert as well, we'll get rid of it soon! <3"
+      ].join("\n"));
+    }    document.getElementById("action-render-widget").addEventListener("click", () => perry.render());
+
     /* Initialize Perry.js */
     const perry = new Perry({
-      /* Enables log monitoring */
+      /* Enables log recording */
       log: true,
       /* Enables click recording */
       clicks: true,
@@ -345,27 +340,12 @@
       enableScreenRecording: true,
       /* Plugins are ways to handle the bug reporting submission */
       plugins: [
-        function ConsoleLogPlugin(reportInfo) {
-          console.log("[Perry Report Info]:", reportInfo);
-          console.log("[Perry Report Info]:", [
-            "",
-            "This was printed by the ConsoleLogPlugin.",
-            "It is implemented inline into this test page.",
-            "To know more about how to implement a Perry Plugin:",
-            "Checkout this page src code or the github repository."
-          ].join("\n"));
-
-          alert([
-            "[Perry Report Info]: Please check your console logs to see the recording report.",
-            "Sorry for the alert as well, we'll get rid of it soon! <3"
-          ].join("\n"));
-        }
+        ConsoleLogPlugin,
       ]
     });
 
-    /* Renders Perry Widget */
-    perry.render();
-
+   /* Attachs listeners to this page code */
+    document.getElementById("action-render-widget").addEventListener("click", () => perry.render());
     document.getElementById("action-log").addEventListener("click", () => console.log('ama simple info log'));
     document.getElementById("action-warn").addEventListener("click", () => console.warn('ama warning'));
     document.getElementById("action-error").addEventListener("click", () => console.error('ama error'));

--- a/src/interfaces/IPerryScreenRecorder.ts
+++ b/src/interfaces/IPerryScreenRecorder.ts
@@ -1,0 +1,9 @@
+import BlobEvent from "@/interfaces/dom/BlobEvent";
+
+export default interface IScreenRecorder {
+  stop(): Promise<void>;
+  start(): Promise<void>;
+  onRecorderStopEvent(): void;
+  onRecorderErrorEvent(error: BlobEvent): void;
+  onRecorderDataAvailableEvent(event: BlobEvent): void;
+}

--- a/src/packages/clear-store/index.ts
+++ b/src/packages/clear-store/index.ts
@@ -1,1 +1,1 @@
-export default localStorage.clear;
+export default () => localStorage.clear();

--- a/src/packages/perry-notify/index.ts
+++ b/src/packages/perry-notify/index.ts
@@ -2,8 +2,12 @@ import FeatureToggleStore from "@/packages/feature-toggle-store";
 import Features from "@/packages/features";
 import writeToStore from "@/packages/write-to-store";
 
-const notify = (error: Error): void =>
-  FeatureToggleStore.is(Features.NOTIFY_LISTENER) && writeToStore({
+const notify = (error: Error): void => {
+  if (!FeatureToggleStore.is(Features.NOTIFY_LISTENER)) {
+    return;
+  }
+
+  writeToStore({
     name: "perry",
     params: {
       message: error.message,
@@ -12,5 +16,6 @@ const notify = (error: Error): void =>
     },
     property: "notify",
   });
+};
 
 export default notify;

--- a/src/packages/perry/index.ts
+++ b/src/packages/perry/index.ts
@@ -1,44 +1,18 @@
-/** Perry Options interface */
 import IPerryOptions from "@/interfaces/IPerryOptions";
-
-/** Perry Report Info interface */
 import IPerryReportInfo from "@/interfaces/IPerryReportInfo";
+import IPerryScreenRecorder from "@/interfaces/IPerryScreenRecorder";
 
-/** Options validator, created with Yup. */
-import isValidOptions from "@/packages/is-valid-options";
-
-/** Default options as a plain js object */
-import defaultOptions from "@/packages/default-options";
-
-/** Clears perry store */
-import clearStore from "@/packages/clear-store";
-
-/** Aggregates info and creates PerryReport */
 import aggregateReport from "@/packages/aggregate-report";
-
-/** Renders the widget into document */
-import renderWidget from "@/packages/render-widget";
-
-/** Setup the listeners and proxies */
-import setupListeners from "@/packages/setup-listeners";
-
-/** Toggles the feature switches to true so the listeners can start to watch */
+import clearStore from "@/packages/clear-store";
+import defaultOptions from "@/packages/default-options";
+import isValidOptions from "@/packages/is-valid-options";
 import startListeners from "@/packages/start-listeners";
-
-/** Toggles the feature switches to false so the listeners stop watching */
 import stopListeners from "@/packages/stop-listeners";
 
-/** Perry stateless notifier */
-import notify from "@/packages/perry-notify";
-
-/** Screen recorder */
-import ScreenRecorder from "@/packages/screen-recorder";
-
-/** Perry.js class definition */
 export default class Perry {
-  public readonly notify = notify;
   private readonly options: IPerryOptions;
-  private readonly screenRecorder: ScreenRecorder;
+  private screenRecorder?: IPerryScreenRecorder;
+  private hasListenersReady: boolean = false;
 
   constructor(options: IPerryOptions = defaultOptions) {
     this.options = {
@@ -50,29 +24,23 @@ export default class Perry {
       throw new Error("Your options are invalid. Please respect the options schema defined in the docs.");
     }
 
-    if (this.options.enableScreenRecording) {
-      this.screenRecorder = new ScreenRecorder({
-        encodingType: "video/webm",
-        videoName: "video",
-      });
-    }
-
     if (this.options.clearOnReload) {
       clearStore();
     }
-
-    setupListeners(this.options);
   }
 
   public start = async () => {
     try {
-      if (this.options.clearOnReload) {
+      await this.setupListeners();
+
+      if (this.options.clearOnStart) {
         clearStore();
       }
 
       startListeners();
 
       if (this.options.enableScreenRecording) {
+        await this.setupScreenRecorder();
         await this.screenRecorder.start();
       }
     } catch (e) {
@@ -84,12 +52,12 @@ export default class Perry {
   public stop = async () => {
     stopListeners();
 
-    if (this.options.enableScreenRecording) {
+    if (this.options.enableScreenRecording && this.screenRecorder) {
       await this.screenRecorder.stop();
     }
   }
 
-  public submit = async (reportInfo: IPerryReportInfo) => {
+  public submit = async (reportInfo: IPerryReportInfo = {}) => {
     const report = aggregateReport(reportInfo);
 
     this.options.plugins.map((plugin) => plugin(report));
@@ -97,9 +65,48 @@ export default class Perry {
     return report;
   }
 
-  public render = () => renderWidget({
-    onStartRecording: this.start,
-    onStopRecording: this.stop,
-    onSubmit: this.submit,
-  })
+  public notify = async (error: Error) => {
+    const { default: notify } =
+      await import(/* webpackChunkName: "perry-notify" */ "@/packages/perry-notify");
+
+    return notify(error);
+  }
+
+  public render = async () => {
+    const { default: renderWidget } =
+      await import(/* webpackChunkName: "perry-render-widget" */ "@/packages/render-widget");
+
+    return renderWidget({
+      onStartRecording: this.start,
+      onStopRecording: this.stop,
+      onSubmit: this.submit,
+    });
+  }
+
+  private setupListeners = async () => {
+    if (this.hasListenersReady) {
+      return;
+    }
+
+    const { default: setupListeners } =
+      await import(/* webpackChunkName: "perry-setup-listeners" */ "@/packages/setup-listeners");
+
+    setupListeners(this.options);
+
+    this.hasListenersReady = true;
+  }
+
+  private setupScreenRecorder = async () => {
+    if (this.screenRecorder) {
+      return;
+    }
+
+    const { default: ScreenRecorder } =
+      await import(/* webpackChunkName: "perry-screen-recorder" */ "@/packages/screen-recorder");
+
+    this.screenRecorder = new ScreenRecorder({
+      encodingType: "video/webm",
+      videoName: "video",
+    });
+  }
 }

--- a/src/packages/screen-recorder/index.ts
+++ b/src/packages/screen-recorder/index.ts
@@ -1,5 +1,6 @@
 import BlobEvent from "@/interfaces/dom/BlobEvent";
 import MediaRecorder from "@/interfaces/dom/MediaRecorder";
+import IPerryScreenRecorder from "@/interfaces/IPerryScreenRecorder";
 import getDisplayMedia from "@/packages/get-display-media";
 import mapBlobListToBase64 from "@/packages/map-blob-list-to-base64";
 import supportsMediaDevices from "@/packages/supports-media-devices";
@@ -20,7 +21,7 @@ export interface IScreenRecorderOptions {
   encodingType: string;
 }
 
-export default class ScreenRecorder {
+export default class ScreenRecorder implements IPerryScreenRecorder {
   private data: Blob[] = [];
   private stream: MediaStream;
   private recorder: MediaRecorder;


### PR DESCRIPTION
Relates to #55.

This PR makes Perry lazy load all the things it uses until it actually starts using them by using Webpack Code Splitting.

Now from master, the end bundle is at **79.4kb**
It currently lazy loads:

 - Perry Widget (saves off **49.7kb** of the end minified bundle)
 - Perry Notify (saves off **429b** of the end minified bundle)
 - Perry Setup Listeners (saves off **1005b** of the end minified bundle)
 - Perry Screen Recorder (saves off **1.8kb** of the end minified bundle)

In total we save more than 50kb from the initial bundle until the user actually needs that code.

Perry Widget gets loaded once you run `perry.render()`
Perry Notify gets loaded once you run `perry.notify(error)`
Perry Setup Listeners gets loaded once you run `perry.start()`
Perry Screen Recorder gets loaded once you run `perry.start()` with `options.enableScreenRecorder` set as `true`

This also changes the documentation, so check the deploy preview.
